### PR TITLE
WIP graphql: support for graphql requests on the same endpoint as rpc

### DIFF
--- a/cmd/geth/retesteth.go
+++ b/cmd/geth/retesteth.go
@@ -896,7 +896,7 @@ func retesteth(ctx *cli.Context) error {
 	}
 
 	handler := node.NewHTTPHandlerStack(srv, cors, vhosts)
-	handler = node.NewWebsocketUpgradeHandler(handler, nil)
+	handler = node.AddWebsocketUpgradeHandler(handler, nil)
 
 	// start http server
 	var RetestethHTTPTimeouts = rpc.HTTPTimeouts{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1622,12 +1622,22 @@ func RegisterGraphQLService(stack *node.Node, endpoint string, cors, vhosts []st
 		// Try to construct the GraphQL service backed by a full node
 		var ethServ *eth.Ethereum
 		if err := ctx.Service(&ethServ); err == nil {
-			return graphql.New(ethServ.APIBackend, endpoint, cors, vhosts, timeouts)
+			if stack.Config().GraphQLPort == stack.Config().HTTPPort {
+				graphqlService, err := graphql.New(ethServ.APIBackend, endpoint, cors, vhosts, timeouts, true)
+				stack.SetGraphQLHandler(graphqlService.Handler())
+				return graphqlService, err
+			}
+			return graphql.New(ethServ.APIBackend, endpoint, cors, vhosts, timeouts, false)
 		}
 		// Try to construct the GraphQL service backed by a light node
 		var lesServ *les.LightEthereum
 		if err := ctx.Service(&lesServ); err == nil {
-			return graphql.New(lesServ.ApiBackend, endpoint, cors, vhosts, timeouts)
+			if stack.Config().GraphQLPort == stack.Config().HTTPPort {
+				graphqlService, err := graphql.New(lesServ.ApiBackend, endpoint, cors, vhosts, timeouts, true)
+				stack.SetGraphQLHandler(graphqlService.Handler())
+				return graphqlService, err
+			}
+			return graphql.New(lesServ.ApiBackend, endpoint, cors, vhosts, timeouts, false)
 		}
 		// Well, this should not have happened, bail out
 		return nil, errors.New("no Ethereum service")

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1622,18 +1622,12 @@ func RegisterGraphQLService(stack *node.Node, endpoint string, cors, vhosts []st
 		// Try to construct the GraphQL service backed by a full node
 		var ethServ *eth.Ethereum
 		if err := ctx.Service(&ethServ); err == nil {
-			if stack.Config().GraphQLPort == stack.Config().HTTPPort {
-				return graphql.New(ethServ.APIBackend, endpoint, cors, vhosts, timeouts, true)
-			}
-			return graphql.New(ethServ.APIBackend, endpoint, cors, vhosts, timeouts, false)
+			return graphql.New(ethServ.APIBackend, endpoint, cors, vhosts, timeouts, stack.Config().GraphQLPort == stack.Config().HTTPPort)
 		}
 		// Try to construct the GraphQL service backed by a light node
 		var lesServ *les.LightEthereum
 		if err := ctx.Service(&lesServ); err == nil {
-			if stack.Config().GraphQLPort == stack.Config().HTTPPort {
-				return graphql.New(lesServ.ApiBackend, endpoint, cors, vhosts, timeouts, true)
-			}
-			return graphql.New(lesServ.ApiBackend, endpoint, cors, vhosts, timeouts, false)
+			return graphql.New(lesServ.ApiBackend, endpoint, cors, vhosts, timeouts, stack.Config().GraphQLPort == stack.Config().HTTPPort)
 		}
 		// Well, this should not have happened, bail out
 		return nil, errors.New("no Ethereum service")

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1623,9 +1623,7 @@ func RegisterGraphQLService(stack *node.Node, endpoint string, cors, vhosts []st
 		var ethServ *eth.Ethereum
 		if err := ctx.Service(&ethServ); err == nil {
 			if stack.Config().GraphQLPort == stack.Config().HTTPPort {
-				graphqlService, err := graphql.New(ethServ.APIBackend, endpoint, cors, vhosts, timeouts, true)
-				stack.SetGraphQLHandler(graphqlService.Handler())
-				return graphqlService, err
+				return graphql.New(ethServ.APIBackend, endpoint, cors, vhosts, timeouts, true)
 			}
 			return graphql.New(ethServ.APIBackend, endpoint, cors, vhosts, timeouts, false)
 		}
@@ -1633,9 +1631,7 @@ func RegisterGraphQLService(stack *node.Node, endpoint string, cors, vhosts []st
 		var lesServ *les.LightEthereum
 		if err := ctx.Service(&lesServ); err == nil {
 			if stack.Config().GraphQLPort == stack.Config().HTTPPort {
-				graphqlService, err := graphql.New(lesServ.ApiBackend, endpoint, cors, vhosts, timeouts, true)
-				stack.SetGraphQLHandler(graphqlService.Handler())
-				return graphqlService, err
+				return graphql.New(lesServ.ApiBackend, endpoint, cors, vhosts, timeouts, true)
 			}
 			return graphql.New(lesServ.ApiBackend, endpoint, cors, vhosts, timeouts, false)
 		}

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -58,7 +58,20 @@ func New(backend ethapi.Backend, endpoint string, cors, vhosts []string, timeout
 func (s *Service) Protocols() []p2p.Protocol { return nil }
 
 // APIs returns the list of APIs exported by this service.
-func (s *Service) APIs() []rpc.API { return nil }
+func (s *Service) APIs() []rpc.API {
+	if s.noStart {
+		return []rpc.API{
+			{
+				Namespace: "graphql_handler",
+				Version:   "",
+				Service:   s.handler,
+				Public:    false,
+			},
+		}
+	}
+
+	return nil
+}
 
 // Start is called after all services have been constructed and the networking
 // layer was also initialized to spawn any goroutines required by the service.
@@ -106,8 +119,4 @@ func (s *Service) Stop() error {
 		log.Info("GraphQL endpoint closed", "url", fmt.Sprintf("http://%s", s.endpoint))
 	}
 	return nil
-}
-
-func (s *Service) Handler() http.Handler {
-	return s.handler
 }

--- a/graphql/service.go
+++ b/graphql/service.go
@@ -35,7 +35,7 @@ type Service struct {
 	cors     []string         // Allowed CORS domains
 	vhosts   []string         // Recognised vhosts
 	timeouts rpc.HTTPTimeouts // Timeout settings for HTTP requests.
-	backend  ethapi.Backend   // The backend that queries will operate onn.
+	backend  ethapi.Backend   // The backend that queries will operate on.
 	handler  http.Handler     // The `http.Handler` used to answer queries.
 	listener net.Listener     // The listening socket.
 

--- a/node/node.go
+++ b/node/node.go
@@ -236,19 +236,17 @@ func (n *Node) Start() error {
 
 			return err
 		}
-
 		// Mark the service started for potential cleanup
 		started = append(started, kind)
 
-		if kind.String() == "*graphql.Service" && service.APIs() != nil { // TODO change this entire conditional, it is ugly
+		// set the graphql handler of the node only if the graphql port and rpc port are the same
+		if n.Config().GraphQLPort == n.Config().HTTPPort && kind.String() == "*graphql.Service" && service.APIs() != nil { // TODO change this entire conditional, it is ugly
 			 graphqlHandler := service.APIs()[0].Service
 			 if handler, ok := graphqlHandler.(http.Handler); ok {
 				 n.SetGraphQLHandler(handler)
 			 }
 		}
 	}
-
-
 	// Lastly start the configured RPC interfaces
 	if err := n.startRPC(services); err != nil {
 		for _, service := range services {

--- a/node/node.go
+++ b/node/node.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/graphql"
 	"github.com/ethereum/go-ethereum/internal/debug"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -240,7 +241,8 @@ func (n *Node) Start() error {
 		started = append(started, kind)
 
 		// set the graphql handler of the node only if the graphql port and rpc port are the same
-		if n.Config().GraphQLPort == n.Config().HTTPPort && kind.String() == "*graphql.Service" && service.APIs() != nil { // TODO change this entire conditional, it is ugly
+		_, ok := service.(*graphql.Service)
+		if n.Config().GraphQLPort == n.Config().HTTPPort && ok && service.APIs() != nil { // TODO change this entire conditional, it is ugly
 			 graphqlHandler := service.APIs()[0].Service
 			 if handler, ok := graphqlHandler.(http.Handler); ok {
 				 n.SetGraphQLHandler(handler)

--- a/node/node.go
+++ b/node/node.go
@@ -382,10 +382,10 @@ func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors
 		handler = NewWebsocketUpgradeHandler(handler, srv.WebsocketHandler(wsOrigins))
 	}
 
-	// TODO graphql support here
-	if n.config.GraphQLEndpoint() == n.httpEndpoint {
-		handler = n.AddGraphQLHandler()
-	}
+	//// TODO graphql support here
+	//if n.config.GraphQLEndpoint() == n.httpEndpoint {
+	//	handler = n.AddGraphQLHandler()
+	//}
 
 	listener, err := rpc.StartHTTPEndpoint(endpoint, timeouts, handler)
 	if err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -240,11 +240,9 @@ func (n *Node) Start() error {
 		// Mark the service started for potential cleanup
 		started = append(started, kind)
 
-		if kind.String() == "*graphql.Service" { // TODO change this
-			log.Error("we are in this ugly condition statement........") // TODO REMOVE
-			 graphqlHandler := service.APIs()[0].Service // TODO FIX THIS, it's so ugly
+		if kind.String() == "*graphql.Service" && service.APIs() != nil { // TODO change this entire conditional, it is ugly
+			 graphqlHandler := service.APIs()[0].Service
 			 if handler, ok := graphqlHandler.(http.Handler); ok {
-				 log.Error("setting Graphql handler!.........") // TODO REMOVE
 				 n.SetGraphQLHandler(handler)
 			 }
 		}
@@ -731,12 +729,6 @@ func RegisterApisFromWhitelist(apis []rpc.API, modules []string, srv *rpc.Server
 }
 
 func (n *Node) SetGraphQLHandler(h http.Handler) {
-	if h != nil {
-		n.graphqlHandler = h
-		log.Error("handler is set SUCCESS") // TODO REMOVE
-		return
-	}
-
-	log.Error("handler came back as nil.... FATAL") // TODO REMOVE
+	n.graphqlHandler = h
 	return
 }

--- a/node/node.go
+++ b/node/node.go
@@ -236,9 +236,21 @@ func (n *Node) Start() error {
 
 			return err
 		}
+
 		// Mark the service started for potential cleanup
 		started = append(started, kind)
+
+		if kind.String() == "*graphql.Service" { // TODO change this
+			log.Error("we are in this ugly condition statement........") // TODO REMOVE
+			 graphqlHandler := service.APIs()[0].Service // TODO FIX THIS, it's so ugly
+			 if handler, ok := graphqlHandler.(http.Handler); ok {
+				 log.Error("setting Graphql handler!.........") // TODO REMOVE
+				 n.SetGraphQLHandler(handler)
+			 }
+		}
 	}
+
+
 	// Lastly start the configured RPC interfaces
 	if err := n.startRPC(services); err != nil {
 		for _, service := range services {
@@ -721,5 +733,10 @@ func RegisterApisFromWhitelist(apis []rpc.API, modules []string, srv *rpc.Server
 func (n *Node) SetGraphQLHandler(h http.Handler) {
 	if h != nil {
 		n.graphqlHandler = h
+		log.Error("handler is set SUCCESS") // TODO REMOVE
+		return
 	}
+
+	log.Error("handler came back as nil.... FATAL") // TODO REMOVE
+	return
 }

--- a/node/node.go
+++ b/node/node.go
@@ -384,6 +384,11 @@ func (n *Node) startHTTP(endpoint string, apis []rpc.API, modules []string, cors
 	// wrap handler in websocket handler only if websocket port is the same as http rpc
 	handler := n.AddWebsocketHandler(NewHTTPHandlerStack(srv, cors, vhosts), ws)
 
+	// TODO graphql support here
+	if n.config.GraphQLEndpoint() == n.httpEndpoint {
+		handler = n.AddGraphQLHandler()
+	}
+
 	listener, err := rpc.StartHTTPEndpoint(endpoint, timeouts, handler)
 	if err != nil {
 		return err
@@ -410,6 +415,8 @@ func (n *Node) AddWebsocketHandler(handler http.Handler, websocket http.Handler)
 
 	return handler
 }
+
+func (n *Node) AddGraphQLHandler( handler http.Handler, )
 
 // stopHTTP terminates the HTTP RPC endpoint.
 func (n *Node) stopHTTP() {

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -169,6 +169,6 @@ func AddGraphQLHandler(h http.Handler, gql http.Handler) http.Handler {
 }
 
 func isGraphQL(r *http.Request) bool {
-	// TODO how to recognise the path ? in header? 
-	return false
+	log.Error("A GRAPH QL REQUEST OMGGGG") // TODO REMOVE
+	return r.Header.Get("Content-type") == "application/graphql" // TODO how to recognise the path ? in header?
 }

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -139,7 +139,7 @@ func newGzipHandler(next http.Handler) http.Handler {
 	})
 }
 
-func NewWebsocketUpgradeHandler(h http.Handler, ws http.Handler) http.Handler {
+func AddWebsocketUpgradeHandler(h http.Handler, ws http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isWebsocket(r) {
 			ws.ServeHTTP(w, r)
@@ -154,4 +154,21 @@ func NewWebsocketUpgradeHandler(h http.Handler, ws http.Handler) http.Handler {
 func isWebsocket(r *http.Request) bool {
 	return strings.ToLower(r.Header.Get("Upgrade")) == "websocket" &&
 		strings.ToLower(r.Header.Get("Connection")) == "upgrade"
+}
+
+func AddGraphQLHandler(h http.Handler, gql http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isGraphQL(r) {
+			gql.ServeHTTP(w, r)
+			log.Debug("serving graphql request")
+			return
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}
+
+func isGraphQL(r *http.Request) bool {
+	// TODO how to recognise the path ? in header? 
+	return false
 }

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -159,6 +159,7 @@ func isWebsocket(r *http.Request) bool {
 func AddGraphQLHandler(h http.Handler, gql http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isGraphQL(r) {
+			log.Error("is graphql! ") // TODO REMOVE
 			gql.ServeHTTP(w, r)
 			log.Debug("serving graphql request")
 			return
@@ -169,6 +170,5 @@ func AddGraphQLHandler(h http.Handler, gql http.Handler) http.Handler {
 }
 
 func isGraphQL(r *http.Request) bool {
-	log.Error("A GRAPH QL REQUEST OMGGGG") // TODO REMOVE
-	return r.Header.Get("Content-type") == "application/graphql" // TODO how to recognise the path ? in header?
+	return r.RequestURI == "/graphql" // TODO how to recognise the path ? in header?
 }

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -159,7 +159,6 @@ func isWebsocket(r *http.Request) bool {
 func AddGraphQLHandler(h http.Handler, gql http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isGraphQL(r) {
-			log.Error("is graphql! ") // TODO REMOVE
 			gql.ServeHTTP(w, r)
 			log.Debug("serving graphql request")
 			return


### PR DESCRIPTION
* graphql requests can now be handled on the same port as rpc requests and even ws requests
* if the specified graphql port differs from the specified rpc port, then a separate server for graphql is started on the specified graphql port.